### PR TITLE
Removed block selector preceding ecosystems view

### DIFF
--- a/docroot/sites/all/themes/chm_theme_kit/css/style.css
+++ b/docroot/sites/all/themes/chm_theme_kit/css/style.css
@@ -9487,10 +9487,10 @@ body.country-portal .logo img {
 #block-system-main {
   margin-bottom: 1em;
 }
-#block-views-ecosystems-block .view-ecosystems tr {
+.view-ecosystems tr {
   display: block;
 }
-#block-views-ecosystems-block .view-ecosystems tr td {
+.view-ecosystems tr td {
   display: block;
   padding: 10vw;
   margin-bottom: 1.5em;
@@ -9500,18 +9500,18 @@ body.country-portal .logo img {
   overflow: hidden;
   box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
 }
-#block-views-ecosystems-block .view-ecosystems tr td .views-field.views-field-field-image {
+.view-ecosystems tr td .views-field.views-field-field-image {
   margin: -10vw -10vw 1em -10vw;
 }
-#block-views-ecosystems-block .view-ecosystems tr td .views-field.views-field-field-image img {
+.view-ecosystems tr td .views-field.views-field-field-image img {
   width: 100%;
 }
-#block-views-ecosystems-block .view-ecosystems tr td .views-field.views-field-title a {
+.view-ecosystems tr td .views-field.views-field-title a {
   color: #039749;
   font-weight: bold;
   font-size: 1.5em;
 }
-#block-views-ecosystems-block .view-ecosystems tr td .views-field.views-field-body {
+.view-ecosystems tr td .views-field.views-field-body {
   font-size: 14px;
   position: relative;
   overflow: hidden;
@@ -9519,7 +9519,7 @@ body.country-portal .logo img {
   min-height: calc(1 * 1.42857143em);
   max-height: calc(3 * 1.42857143em);
 }
-#block-views-ecosystems-block .view-ecosystems tr td .views-field.views-field-body:after {
+.view-ecosystems tr td .views-field.views-field-body:after {
   content: "";
   text-align: right;
   position: absolute;
@@ -9539,7 +9539,7 @@ body.country-portal .logo img {
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00ffffff', endColorstr='#f5f5f5', GradientType=1);
   /* IE6-9 */
 }
-#block-views-ecosystems-block .view-ecosystems tr td .views-field.views-field-view-node {
+.view-ecosystems tr td .views-field.views-field-view-node {
   display: inline-block;
   text-transform: uppercase;
   font-weight: bold;
@@ -9547,35 +9547,35 @@ body.country-portal .logo img {
   margin-top: .5em;
 }
 @media all and (min-width: 480px) {
-  #block-views-ecosystems-block .view-ecosystems tr td {
+  .view-ecosystems tr td {
     padding: 2em;
     padding-bottom: 0;
   }
-  #block-views-ecosystems-block .view-ecosystems tr td .views-field.views-field-field-image {
+  .view-ecosystems tr td .views-field.views-field-field-image {
     margin: -2em -2em 1em -2em;
   }
-  #block-views-ecosystems-block .view-ecosystems tr td .views-field.views-field-field-image img {
+  .view-ecosystems tr td .views-field.views-field-field-image img {
     width: 35%;
     float: left;
     margin-right: 1em;
   }
-  #block-views-ecosystems-block .view-ecosystems tr td .views-field.views-field-title a {
+  .view-ecosystems tr td .views-field.views-field-title a {
     font-size: 1.7em;
   }
-  #block-views-ecosystems-block .view-ecosystems tr td .views-field.views-field-body {
+  .view-ecosystems tr td .views-field.views-field-body {
     max-height: calc(2 * 1.42857143em);
   }
 }
 @media all and (min-width: 768px) {
-  #block-views-ecosystems-block .view-ecosystems tr td .views-field.views-field-title {
+  .view-ecosystems tr td .views-field.views-field-title {
     margin-bottom: 0.5em;
   }
-  #block-views-ecosystems-block .view-ecosystems tr td .views-field.views-field-body {
+  .view-ecosystems tr td .views-field.views-field-body {
     max-height: calc(3 * 1.42857143em);
   }
 }
 @media all and (min-width: 992px) {
-  #block-views-ecosystems-block .view-ecosystems tr td .views-field.views-field-field-image img {
+  .view-ecosystems tr td .views-field.views-field-field-image img {
     width: 220px;
   }
 }

--- a/docroot/sites/all/themes/chm_theme_kit/less/content.less
+++ b/docroot/sites/all/themes/chm_theme_kit/less/content.less
@@ -977,105 +977,103 @@
   margin-bottom: 1em;
 }
 
-#block-views-ecosystems-block {
-  .view-ecosystems {
-    tr{
+.view-ecosystems {
+  tr{
+    display: block;
+    td{
       display: block;
-      td{
-        display: block;
-        padding: 10vw;
-        margin-bottom: 1.5em;
-        background-color: #f5f5f5;
-        border: 1px solid #e3e3e3;
-        border-radius: 5px;
+      padding: 10vw;
+      margin-bottom: 1.5em;
+      background-color: #f5f5f5;
+      border: 1px solid #e3e3e3;
+      border-radius: 5px;
+      overflow: hidden;
+      box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+      .views-field.views-field-field-image {
+        margin: -10vw -10vw 1em -10vw;
+        img{
+          width: 100%;
+        }
+      }
+      .views-field.views-field-title a {
+        color: @navbar-color;
+        font-weight: bold;
+        font-size: 1.5em;
+      }
+      .views-field.views-field-body {
+        font-size: 14px;
+        position: relative;
         overflow: hidden;
-        box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
-        .views-field.views-field-field-image {
-          margin: -10vw -10vw 1em -10vw;
-          img{
-            width: 100%;
+        padding: 0;
+        min-height: ~"calc(1 * @{line-height-em})";
+        max-height: ~"calc(3 * @{line-height-em})";
+        &:after {
+          content: "";
+          text-align: right;
+          position: absolute;
+          bottom: 0;
+          right: 0;
+          left: auto;
+          width: 70%;
+          height: @line-height-em;
+          pointer-events: none;
+          /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#ffffff+0,f5f5f5+100&0+0,1+100 */
+          background: -moz-linear-gradient(left,  rgba(255,255,255,0) 0%, rgba(245,245,245,1) 100%); /* FF3.6-15 */
+          background: -webkit-linear-gradient(left,  rgba(255,255,255,0) 0%,rgba(245,245,245,1) 100%); /* Chrome10-25,Safari5.1-6 */
+          background: linear-gradient(to right,  rgba(255,255,255,0) 0%,rgba(245,245,245,1) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+          filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#f5f5f5',GradientType=1 ); /* IE6-9 */
+
+        }
+      }
+      .views-field.views-field-view-node {
+        display: inline-block;
+        text-transform: uppercase;
+        font-weight: bold;
+        font-size: 0.8em;
+        margin-top: .5em;
+      }
+    }
+  }
+  
+  @media all and (min-width: @screen-xs-min) {
+    tr{
+      td{
+        padding: 2em;
+        padding-bottom: 0;
+        .views-field.views-field-field-image { 
+          margin: -2em -2em 1em -2em;
+          img {
+            width: 35%;
+            float: left;
+            margin-right: 1em;
           }
         }
         .views-field.views-field-title a {
-          color: @navbar-color;
-          font-weight: bold;
-          font-size: 1.5em;
+          font-size: 1.7em;
         }
         .views-field.views-field-body {
-          font-size: 14px;
-          position: relative;
-          overflow: hidden;
-          padding: 0;
-          min-height: ~"calc(1 * @{line-height-em})";
+          max-height: ~"calc(2 * @{line-height-em})";
+        }
+      }
+    }
+  }
+  @media all and (min-width: @screen-sm-min) {
+    tr{
+      td{
+        .views-field.views-field-title {
+          margin-bottom: 0.5em;
+        }
+        .views-field.views-field-body {
           max-height: ~"calc(3 * @{line-height-em})";
-          &:after {
-            content: "";
-            text-align: right;
-            position: absolute;
-            bottom: 0;
-            right: 0;
-            left: auto;
-            width: 70%;
-            height: @line-height-em;
-            pointer-events: none;
-            /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#ffffff+0,f5f5f5+100&0+0,1+100 */
-            background: -moz-linear-gradient(left,  rgba(255,255,255,0) 0%, rgba(245,245,245,1) 100%); /* FF3.6-15 */
-            background: -webkit-linear-gradient(left,  rgba(255,255,255,0) 0%,rgba(245,245,245,1) 100%); /* Chrome10-25,Safari5.1-6 */
-            background: linear-gradient(to right,  rgba(255,255,255,0) 0%,rgba(245,245,245,1) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
-            filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#00ffffff', endColorstr='#f5f5f5',GradientType=1 ); /* IE6-9 */
-
-          }
-        }
-        .views-field.views-field-view-node {
-          display: inline-block;
-          text-transform: uppercase;
-          font-weight: bold;
-          font-size: 0.8em;
-          margin-top: .5em;
         }
       }
     }
-    
-    @media all and (min-width: @screen-xs-min) {
-      tr{
-        td{
-          padding: 2em;
-          padding-bottom: 0;
-          .views-field.views-field-field-image { 
-            margin: -2em -2em 1em -2em;
-            img {
-              width: 35%;
-              float: left;
-              margin-right: 1em;
-            }
-          }
-          .views-field.views-field-title a {
-            font-size: 1.7em;
-          }
-          .views-field.views-field-body {
-            max-height: ~"calc(2 * @{line-height-em})";
-          }
-        }
-      }
-    }
-    @media all and (min-width: @screen-sm-min) {
-      tr{
-        td{
-          .views-field.views-field-title {
-            margin-bottom: 0.5em;
-          }
-          .views-field.views-field-body {
-            max-height: ~"calc(3 * @{line-height-em})";
-          }
-        }
-      }
-    }
-    @media all and (min-width: @screen-md-min) {
-      tr{
-        td{
-          .views-field.views-field-field-image img {
-            width: 220px;
-          }
+  }
+  @media all and (min-width: @screen-md-min) {
+    tr{
+      td{
+        .views-field.views-field-field-image img {
+          width: 220px;
         }
       }
     }


### PR DESCRIPTION
This applies the same style from /biodiversity to all .view-ecosystems blocks (e.g. /ecosystems )